### PR TITLE
/workflows/bulk-cancel: also cancel task with status INIT and WAIT

### DIFF
--- a/workflow/views.py
+++ b/workflow/views.py
@@ -225,7 +225,9 @@ class WorkflowViewSet(ModelViewSet):
         valid = serializer.is_valid(raise_exception=False)  # noqa: F841
 
         data = serializer.validated_data
-        workflows = Workflow.objects.filter(id__in=data["ids"], status=Workflow.STATUS_PROGRESS)
+        workflows = Workflow.objects.filter(
+            id__in=data["ids"], status__in=[Workflow.STATUS_INIT, Workflow.STATUS_PROGRESS, Workflow.STATUS_WAIT]
+        )
         for workflow in workflows:
             workflow.cancel()
 


### PR DESCRIPTION
Previously, only tasks with status PROGRESS were cancelled. This brings it in line with /workflow/{id}/cancel.

Also added a test to verify the behaviour and changed the tasks in `setUp()` with state 'pending' to 'wait', since 'pending' is not a valid task state.

Fixes finmars-platform/finmars-core#92