### PR TITLE
fix(scheduler): persist last_run_at per-tenant schema to stop duplicate schedule fires

### DIFF
--- a/workflow/schedulers.py
+++ b/workflow/schedulers.py
@@ -1,4 +1,5 @@
 from celery.utils.log import get_logger
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import DatabaseError, InterfaceError
 from django_celery_beat.schedulers import DatabaseScheduler as DCBScheduler
 
@@ -50,3 +51,35 @@ class DatabaseScheduler(DCBScheduler):
         finally:
             self._last_timestamp = ts
         return False
+
+    def sync(self):
+        """Persist each dirty entry UNDER ITS OWN tenant schema.
+
+        Entries are keyed ``"<schema>:<name>"`` by :meth:`all_as_schedule`. The
+        base :class:`DatabaseScheduler.sync` saves them under whatever
+        ``search_path`` happens to be active at sync time, so in this
+        multitenant setup ``last_run_at`` / ``total_run_count`` land in the
+        wrong schema (or nowhere) and never advance for the tenant. beat then
+        keeps re-sending the same scheduled task on every cycle while the due
+        window is open — observed as ``portfolio_history`` firing 3-4x/night in
+        space0uph9. ``total_run_count`` staying ``0`` in the DB is the tell-tale
+        of that bug. Setting the schema per entry before ``save()`` fixes it.
+        """
+        info("DatabaseScheduler: Writing entries (multitenant, per-schema)...")
+        _failed = set()
+        try:
+            while self._dirty:
+                name = self._dirty.pop()
+                schema = name.split(":", 1)[0]
+                try:
+                    set_schema_from_context({"space_code": schema})
+                    self.schedule[name].save()
+                except (KeyError, ObjectDoesNotExist):
+                    _failed.add(name)
+        except DatabaseError as exc:
+            logger.exception("DatabaseScheduler: Database error while sync: %r", exc)
+        except InterfaceError:
+            warning("DatabaseScheduler: InterfaceError in sync(), waiting to retry in next call...")
+        finally:
+            # Re-queue entries we could not save so the next sync retries them.
+            self._dirty |= _failed


### PR DESCRIPTION
## Problem

The custom multitenant `DatabaseScheduler` (`workflow/schedulers.py`) loads schedules across all tenant schemas and keys entries `"<schema>:<name>"`, but does **not** override `sync()`. The base django-celery-beat `sync()` saves each dirty entry's `last_run_at` / `total_run_count` under whatever DB `search_path` is active at sync time — not the entry's schema. So the bookkeeping lands in the wrong schema (or nowhere) and `last_run_at` never advances for the tenant.

Consequence: the crontab stays **due** on every beat cycle until the workflow task itself finally runs and stamps `last_run_at`. When the workflow launch is delayed (busy workers / ordering gate), beat re-sends the same scheduled task several times.

### Observed (realm04pdn / space0uph9, Mars Capital)

`portfolio_history` (cron `30 1`) fired **3–4×/night**; `register` / `price_history` fired once. Beat log:

```
01:30:00  Sending due task portfolio_history
01:30:30  Sending due task portfolio_history
01:35:32  Sending due task portfolio_history
01:40:34  Sending due task portfolio_history
```

DB tell-tale: `total_run_count = 0` on all schedules despite nightly runs. Result: 3–4× duplicate heavy calculations in parallel, duplicate `PortfolioHistory` rows, ~9h runtime instead of ~2h.

## Fix

Override `sync()` to `set_schema_from_context({"space_code": <entry schema>})` per dirty entry (schema parsed from the `"<schema>:<name>"` key) before `save()`. Entries that can't be saved are re-queued for the next sync, matching base-class semantics.

## Verification

- After deploy, `total_run_count` should become `> 0` (regression signal).
- A schedule whose launch is delayed should fire exactly once.

## Notes

Space-level stop-gaps are already live for space0uph9 while this lands: a duplicate-run guard in the `helper-calculate-portfolio-history` workflow module + retimed cron. This PR is the platform root fix and covers **all** schedules / tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
