### PR TITLE
fix(scheduler): swallow per-entry sync errors so beat stays up

### DIFF
--- a/workflow/schedulers.py
+++ b/workflow/schedulers.py
@@ -88,7 +88,8 @@ class DatabaseScheduler(DCBScheduler):
                     # for space0uph9. Log and re-queue instead of dying.
                     logger.exception(
                         "DatabaseScheduler: skipping entry %r due to error: %r",
-                        name, exc,
+                        name,
+                        exc,
                     )
                     _failed.add(name)
         except DatabaseError as exc:

--- a/workflow/schedulers.py
+++ b/workflow/schedulers.py
@@ -76,6 +76,21 @@ class DatabaseScheduler(DCBScheduler):
                     self.schedule[name].save()
                 except (KeyError, ObjectDoesNotExist):
                     _failed.add(name)
+                except Exception as exc:
+                    # Never let a single bad entry (e.g. stale schema no longer
+                    # in tenant list, transient save failure) escape and crash
+                    # beat -- otherwise the pod restarts, last_run_at is not
+                    # persisted, and beat re-fires the "due" task on every tick
+                    # after restart. Observed 2026-08-11: a stale schema entry
+                    # made set_schema_from_context raise, sync() propagated the
+                    # exception into beat.tick(), the pod restarted, and beat
+                    # then dispatched portfolio_history 316 times in 89 minutes
+                    # for space0uph9. Log and re-queue instead of dying.
+                    logger.exception(
+                        "DatabaseScheduler: skipping entry %r due to error: %r",
+                        name, exc,
+                    )
+                    _failed.add(name)
         except DatabaseError as exc:
             logger.exception("DatabaseScheduler: Database error while sync: %r", exc)
         except InterfaceError:


### PR DESCRIPTION
## Problem
The multitenant `sync()` override in `DatabaseScheduler` catches only `(KeyError, ObjectDoesNotExist)` inside the per-entry try block. Any other exception — for example `set_schema_from_context({"space_code": schema})` raising a plain `Exception` when a stale entry’s schema is no longer in `get_all_tenant_schemas()` — escapes `sync()`, propagates through `DatabaseScheduler.schedule` and `beat.tick()`, and kills the beat process.

## Impact (observed)
Realm `realm04pdn`, space `space0uph9`:
- `workflow-scheduler` pod restarted **254 times** in the month after the previous scheduler fix was deployed (2026-07-13 → 2026-08-13).
- 2026-08-11: a scheduler restart coincided with a user cancelling four in-progress `helper-calculate-portfolio-price-history` workflows. After each restart beat treated `portfolio_history` as due, dispatched `workflow.tasks.workflows.execute`, crashed again on the same bad entry, restarted, dispatched again.
- Result: **316 `portfolio_history` workflows** fired in **89 minutes**, all with the same payload (T-22 × 30 portfolios), before the loop finally settled. To the user this looked like an uncontrolled cascade.

## Fix
Add an outer `except Exception` inside the per-entry `try` block that mirrors the existing `(KeyError, ObjectDoesNotExist)` branch: log the entry name and error, add it to `_failed` so it gets re-queued for the next sync, and continue with the rest of `_dirty`. One healthy schedule can no longer be taken down by an unrelated broken entry.

Diff is 15 lines (comment + `except`), no behavior change on the happy path.

## Rollout notes
- Deploying this fix will stop the ~254 restarts/month on `workflow-scheduler-realm04pdn`. Once beat is stable, `last_run_at` gets persisted normally on each tick and the "keep re-firing because we crashed before saving" pattern goes away.
- No schema changes, no migrations, no data touched.
